### PR TITLE
Added Dynamic Response to HTTPServer

### DIFF
--- a/LoggingHelper.py
+++ b/LoggingHelper.py
@@ -26,6 +26,10 @@ def addrstr(addr):
         logging.warning('unexpected address length: %d' % sz)
         return hexstr(addr)
 
+def portstr(nbo_port):
+  """Returns a host byte order string for the given network byte order port."""
+  return str(struct.unpack('>H', nbo_port)[0])
+
 def split_then_join(s, chunk_sz, join_str):
     """Splits s into chunk_sz chunks and then joins those chunks using join_str."""
     return join_str.join([s[i*chunk_sz:(i+1)*chunk_sz] for i in range((len(s)-1)/chunk_sz+1)])


### PR DESCRIPTION
Hey David,

I added the dynamic response tag handling to HTTPServer as you suggested. I tested by forging packets, and sending them into __make_response, but i didn't actually get VNS to run, though I didnt spend too much time trying (max os x says PF_PACKET doesnt exist and my linux box errored installing some dep). Either way, it _should_ work, but test beforehand!

I think in the long run, it may be cool to add a way to dump the entire packet the HTTPServer got. perhaps have that listening on /dump or :8080/dump to not interfere with the regular http functionality. I can write this later if you like the idea.
